### PR TITLE
Update powerline.css

### DIFF
--- a/powerline.css
+++ b/powerline.css
@@ -108,6 +108,7 @@ footer.statusbar {
 /* second from left */
 .statusbar-item.left.first-visible-item {
     margin-right: -2px; /* avoid 1px leak on right if only 2 items are visible */
+    background-color: transparent !important;
 }
 /* first from right */
 .statusbar-item.right:not([aria-hidden]):not([aria-label=""]) {

--- a/powerline.css
+++ b/powerline.css
@@ -76,6 +76,12 @@ div.vscode-theme-solarized-dark-themes-solarized-dark-color-theme-json footer.st
 }
 
 /* Main styles */
+.statusbar-item.remote-kind {
+    background-color: transparent !important;
+}
+.monaco-workbench .part.statusbar>.items-container>.statusbar-item.remote-kind a:hover:not(.disabled) {
+    background-color: transparent !important;
+}
 
 footer.statusbar {
     background-color: var(--powerline-normal-bg) !important;
@@ -325,7 +331,7 @@ footer.statusbar {
 .statusbar-item.left.first-visible-item ~ .statusbar-item.left:not(#vscodevim\.vim\.primary) a,
 .statusbar-item.left.first-visible-item ~ .statusbar-item.left:not([aria-label^="-- "]) a,
 .statusbar-item.right:not([aria-hidden]):not([aria-label=""]) ~ .statusbar-item.right:not([aria-hidden]):not([aria-label=""]) ~ .statusbar-item.right:not([aria-hidden]):not([aria-label=""]) a {
-    background-color: var(--powerline-inner-bg);
+    background-color: var(--powerline-inner-bg) !important;
     background-image: none;
 }
 /* fourth from left: left arrow */

--- a/powerline.css
+++ b/powerline.css
@@ -77,6 +77,7 @@ div.vscode-theme-solarized-dark-themes-solarized-dark-color-theme-json footer.st
 
 /* Main styles */
 .statusbar-item.remote-kind {
+    color: inherit !important;
     background-color: transparent !important;
 }
 .monaco-workbench .part.statusbar>.items-container>.statusbar-item.remote-kind a:hover:not(.disabled) {


### PR DESCRIPTION
Fixed the color issue brought by the `remote-kind` class, including the background issue when using normal mode of vim, and the hover color issue.

Before:
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/05bb10c2-6c47-44a0-b8a0-bd39d123aec5)
After:
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/ff74f982-ccfb-4c83-a06c-182af3f37127)


Before:
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/a8ece049-6721-410d-ad3e-4afc295af966)
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/3042745f-8d77-4522-bb7f-ba355e4af822)
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/76421024-5a1f-4047-a4dd-65958d95ea37)
After:
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/db715d34-9ac1-46e4-a6f1-47c9f878a953)
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/a16f5ac9-7b7e-4424-a953-dae1739a33eb)
![image](https://github.com/pcwalton/vscode-powerline/assets/7274689/138b9d56-901c-4cb7-923d-5e9128219e25)
